### PR TITLE
User sampling fix

### DIFF
--- a/lib/models/tencent_agent/user_filter.rb
+++ b/lib/models/tencent_agent/user_filter.rb
@@ -6,9 +6,8 @@ class TencentAgent
     SPECIAL_CITIES = [11, 12, 31, 50]
 
     def filter(user)
-      return unless filter_by_city(user)
-      return unless filter_by_gender(user)
-      filter_by_birth_year(user)
+      filter_by_city(user)
+      filter_by_gender(user)
     end
 
     private
@@ -17,13 +16,13 @@ class TencentAgent
     def filter_by_city(user)
       case user['province_code'].to_i
       when 0
-        return nil
+        # Do nothing to not filter out user
       when *SPECIAL_CITIES
         user['city'] = get_location_by_key(user['province_code'])
       else
         case user['city_code'].to_i
         when 0
-          return nil
+          # Do nothing to not filter out user
         else
           key = user['province_code'].to_s + ':' + user['city_code']
           user['city'] = get_location_by_key(key)
@@ -35,17 +34,13 @@ class TencentAgent
     def filter_by_gender(user)
       case user['sex']
       when 0
-        return nil
+        user['gender'] = 'both'
       when 1
         user['gender'] = 'male'
       when 2
         user['gender'] = 'female'
       end
       user
-    end
-
-    def filter_by_birth_year(user)
-      user['birth_year'].zero? ? nil : user
     end
 
     def get_location_by_key(key)

--- a/lib/models/tencent_agent/users_gathering.rb
+++ b/lib/models/tencent_agent/users_gathering.rb
@@ -52,18 +52,14 @@ class TencentAgent
         record_user_sample(user_name, keyword) if keyword
         user = UserFilter.filter(result['data'])
 
-        if user
-          group_ids = get_group_ids(user)
+        group_ids = get_group_ids(user)
 
-          unless group_ids.empty?
-            publish_user(user)
-            group_ids.each do |group_id|
-              publish_user_to_group(user, group_id)
-            end
-            return true
+        unless group_ids.empty?
+          publish_user(user)
+          group_ids.each do |group_id|
+            publish_user_to_group(user, group_id)
           end
-        else
-          $logger.notice log(%{Skip invalid user "#{user_name}"})
+          return true
         end
 
       else

--- a/lib/models/tencent_agent/users_gathering.rb
+++ b/lib/models/tencent_agent/users_gathering.rb
@@ -49,7 +49,7 @@ class TencentAgent
       result = cached_get('api/user/other_info', name: user_name)
 
       if result['ret'].zero? && result['data']
-        record_user_sample(user_name, keyword)
+        record_user_sample(user_name, keyword) if keyword
         user = UserFilter.filter(result['data'])
 
         if user


### PR DESCRIPTION
- Store all users sampled from Tencent Weibo
- Do not record user sample comes from home timeline

Before this fix, the users gathered from home timeline also record as
user sample, which is wrong. Also after switched to use list timeline
instead of home timeline, we'll no longer need to add user from timeline
tweets.
