### PR TITLE
Should use RPUSH to add user name to the tracking queue

### DIFF
--- a/lib/models/tencent_agent/users_gathering.rb
+++ b/lib/models/tencent_agent/users_gathering.rb
@@ -51,7 +51,7 @@ class TencentAgent
 
       $redis.sadd(SAMPLE_USER_KEYWORDS % user_name, keyword)
 
-      $redis.lpush(UsersTracking::USERS_TRACKING_QUEUE, user_name)
+      $redis.rpush(UsersTracking::USERS_TRACKING_QUEUE, user_name)
     end
 
     def try_publish_user(user_name, keyword = nil)

--- a/lib/models/tencent_agent/users_tracking.rb
+++ b/lib/models/tencent_agent/users_tracking.rb
@@ -8,6 +8,7 @@ class TencentAgent
     def track_users
       $logger.notice log('Tracking users...')
 
+      # Tencent Weibo's add_to_list API accept at most 8 user names per request.
       while user_names = $redis.lrange(USERS_TRACKING_QUEUE, 0, 7) and !user_names.empty?
         if track_users_by_list(user_names)
           $redis.ltrim(USERS_TRACKING_QUEUE, user_names.size, -1)


### PR DESCRIPTION
Should use RPUSH since the queue will be processed from left:
https://github.com/transist/echidna-spider/blob/master/lib/models/tencent_agent/users_tracking.rb#L11

And I think when use Redis's LIST as queue, it's more natural for
human's brain to use RPUSH to enqueue, not only the direction is natural, but also
the description of RPUSH command is "Append one or multiple values to a
list".
